### PR TITLE
added context acessor for ruby 1.8 compatability

### DIFF
--- a/lib/puppet_https.rb
+++ b/lib/puppet_https.rb
@@ -13,6 +13,7 @@ class PuppetHttps
   end
 
   def make_ssl_request(url, req)
+    Net::HTTP.ssl_context_accessor 'ssl_version'
     connection = Net::HTTP.new(url.host, url.port)
     # connection.set_debug_output $stderr
     connection.use_ssl = true


### PR DESCRIPTION
I'd like to use this gem in the tooling for our Intro to puppet class, but it doesn't work with the stock CentOS ruby.  This fixes it on ruby1.8.  I also tested it with ruby1.9.3 and it still works.
