### PR TITLE
(#5) Ensure request was properly made before finding group id

### DIFF
--- a/lib/puppetclassify/groups.rb
+++ b/lib/puppetclassify/groups.rb
@@ -21,7 +21,13 @@ class Groups
   def get_group_id(group_name)
     groups_res = @puppet_https.get("#{@nc_api_url}/v1/groups")
 
-    groups = JSON.parse(groups_res.body)
+    unless groups_res.code.to_i != 200
+      groups = JSON.parse(groups_res.body)
+    else
+      STDERR.puts "An error occured with your request: HTTP #{groups_res.code} #{groups_res.message}"
+      STDERR.puts groups_res.body
+      exit 1
+    end
 
     group_info = groups.find { |group| group['name'] == group_name }
 

--- a/puppetclassify.gemspec
+++ b/puppetclassify.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'puppetclassify'
-  s.version     = '0.1.0'
+  s.version     = '0.1.1'
   s.date        = '2014-10-30'
   s.summary     = 'Puppet Classify!'
   s.description = 'A ruby library to interface with the classifier service'


### PR DESCRIPTION
Prior to this commit, if a classifier api request failed in the
get_group_id function, it would not do any checks to ensure that it was
successful and would attempt to find the id. This commit fixes that by
first ensuring that the request was successful before attempting to find
the group id.
