### PR TITLE
Show response body if request fails

### DIFF
--- a/lib/puppetclassify/environments.rb
+++ b/lib/puppetclassify/environments.rb
@@ -21,6 +21,7 @@ class Environments
 
     unless env_res.code.to_i == 201
       STDERR.puts "An error occured saving the environment: HTTP #{env_res.code} #{env_res.message}"
+      STDERR.puts env_res.body
     end
   end
 end

--- a/lib/puppetclassify/groups.rb
+++ b/lib/puppetclassify/groups.rb
@@ -54,6 +54,7 @@ class Groups
 
     if res.code.to_i >= 400
       STDERR.puts "An error occured creating the group: HTTP #{res.code} #{res.message}"
+      STDERR.puts res.body
     else
       unless group_info['id']
         res['location'].split("/")[-1]
@@ -69,6 +70,7 @@ class Groups
 
     unless group_res.code.to_i == 200
       STDERR.puts "Update Group failed: HTTP #{group_res.code} #{group_res.message}"
+      STDERR.puts group_res.body
     end
   end
 
@@ -76,6 +78,7 @@ class Groups
     group_res = @puppet_https.delete("#{@nc_api_url}/v1/groups/#{group_id}")
     if group_res.code.to_i != 204
       STDERR.puts "An error occured deleting the group: HTTP #{group_res.code} #{group_res.message}"
+      STDERR.puts group_res.body
     end
   end
 end

--- a/puppetclassify.gemspec
+++ b/puppetclassify.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'puppetclassify'
-  s.version     = '0.1.1'
+  s.version     = '0.1.2'
   s.date        = '2014-10-30'
   s.summary     = 'Puppet Classify!'
   s.description = 'A ruby library to interface with the classifier service'


### PR DESCRIPTION
Prior to this commit, several functions would leave out the request body
if the NC returned an error. This commit updates that by also showing
the request body if something goes wrong.
