### PR TITLE
Added read_timeout into https settings hash 

### DIFF
--- a/lib/puppet_https.rb
+++ b/lib/puppet_https.rb
@@ -7,7 +7,7 @@ class PuppetHttps
     #   - ca_certificate_path
     #   - certificate_path
     #   - private_key_path
-    #
+    #   - read_timeout
 
     @settings = settings
   end
@@ -17,6 +17,7 @@ class PuppetHttps
     # connection.set_debug_output $stderr
     connection.use_ssl = true
     connection.ssl_version = :TLSv1
+    connection.read_timeout = @settings['read_timeout'] || 60 #A default timeout value
 
     connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
     ca_file = @settings['ca_certificate_path']


### PR DESCRIPTION
Hey. 

Sometimes default 60 seconds read_timeout is not enough for update_classes.update method to finish. It would be nice to have it as one of the settings parameter. 
