### PR TITLE
Update groups class to use pin and unpin functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,34 @@ facts = { 'fact' => Facter.to_hash }
 puppetclassify.classification.get('myhostname.puppetlabs.vm', facts)
 ```
 
+### Pinning and unpinning nodes to a group in Puppet enterprise
+
+If you want to "pin" a node to a specific group so it gets that classification, you can
+invoke the pin_nodes command. And if you want to remove nodes from that group, you can run
+the unpin_nodes command.
+
+```
+require 'puppetclassify'
+# URL of classifier as well as certificates and private key for auth
+auth_info = {
+  "ca_certificate_path" => "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+  "certificate_path"    => "/etc/puppetlabs/puppet/ssl/certs/myhostname.vm.pem",
+  "private_key_path"    => "/etc/puppetlabs/puppet/ssl/private_keys/myhostname.vm.pem"
+}
+
+classifier_url = 'https://puppetmaster.local:4433/classifier-api'
+puppetclassify = PuppetClassify.new(classifier_url, auth_info)
+
+my_group_id = puppetclassify.groups.get_group_id("My Super Awesome Group Name")
+
+nodes = ["hostname.com", "myotherhost.com", "anotherhost.com"]
+# pin nodes to group
+puppetclassify.groups.pin_nodes(my_group_id, nodes)
+
+# unpin nodes from group
+puppetclassify.groups.unpin_nodes(my_group_id, nodes)
+```
+
 ## Library Docs
 
 [rubydoc](http://www.rubydoc.info/gems/puppetclassify/0.1.0)

--- a/lib/puppetclassify/groups.rb
+++ b/lib/puppetclassify/groups.rb
@@ -81,4 +81,26 @@ class Groups
       STDERR.puts group_res.body
     end
   end
+
+  def pin_nodes(group_id, node_hash)
+    request_body = {}
+    request_body["nodes"] = node_hash # expects node_hash to be array, i.e. ["foo", "bar", "baz"]
+    group_response = @puppet_https.post("#{@nc_api_url}/v1/groups/#{group_id}/pin", request_body.to_json)
+
+    unless group_response.code.to_i == 204
+      STDERR.puts "An error occured pinning nodes the group: HTTP #{group_response.code} #{group_response.message}"
+      STDERR.puts group_response.body
+    end
+  end
+
+  def unpin_nodes(group_id, node_hash)
+    request_body = {}
+    request_body["nodes"] = node_hash # expects node_hash to be array, i.e. ["foo", "bar", "baz"]
+    group_response = @puppet_https.post("#{@nc_api_url}/v1/groups/#{group_id}/unpin", request_body.to_json)
+
+    unless group_response.code.to_i == 204
+      STDERR.puts "An error occured unpinning nodes the group: HTTP #{group_response.code} #{group_response.message}"
+      STDERR.puts group_response.body
+    end
+  end
 end

--- a/puppetclassify.gemspec
+++ b/puppetclassify.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'puppetclassify'
-  s.version     = '0.1.3'
+  s.version     = '0.1.4'
   s.date        = '2014-10-30'
   s.summary     = 'Puppet Classify!'
   s.description = 'A ruby library to interface with the classifier service'

--- a/spec/puppetclassify/groups_spec.rb
+++ b/spec/puppetclassify/groups_spec.rb
@@ -98,4 +98,29 @@ describe Groups do
     end
   end
 
+  describe "#pin_nodes" do
+    let(:id) { id = "fc500c43-5065-469b-91fc-37ed0e500e81" }
+    let(:nodes) { nodes = ["foo", "bar", "baz"] }
+
+    it "pins a node to a given group" do
+      stub_request(:post, "#{@classifier_url}/v1/groups/#{id}/pin").
+         with(:body => "{\"nodes\":[\"foo\",\"bar\",\"baz\"]}",
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}).
+         to_return(:status => 204, :body => "", :headers => {})
+      expect(@puppetclassify.groups.pin_nodes(id, nodes)).to be_nil
+    end
+  end
+
+  describe "#unpin_nodes" do
+    let(:id) { id = "fc500c43-5065-469b-91fc-37ed0e500e81" }
+    let(:nodes) { nodes = ["foo", "bar", "baz"] }
+
+    it "pins a node to a given group" do
+      stub_request(:post, "#{@classifier_url}/v1/groups/#{id}/unpin").
+         with(:body => "{\"nodes\":[\"foo\",\"bar\",\"baz\"]}",
+              :headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}).
+         to_return(:status => 204, :body => "", :headers => {})
+      expect(@puppetclassify.groups.unpin_nodes(id, nodes)).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
This commit adds a new function pin_nodes and unpin_nodes for the groups
endpoint. A user can supply an array of hostnames to pin or unpin to a
specific group.
