### PR TITLE
(maint) Bump tls to v1.2

### DIFF
--- a/lib/puppet_https.rb
+++ b/lib/puppet_https.rb
@@ -70,7 +70,7 @@ class PuppetHttps
     # connection.set_debug_output $stderr
 
     connection.use_ssl      = true
-    connection.ssl_version  = :TLSv1
+    connection.ssl_version  = :TLSv1_2
     connection.verify_mode  = OpenSSL::SSL::VERIFY_PEER
     connection.ca_file      = @ca_file if @ca_file
     connection.read_timeout = @read_timeout


### PR DESCRIPTION
PE has deprecated tlsv1 tlsv1.1 in Kearney, but has TLSv1.2 transport in
all currently supported versions.