### PR TITLE
Replace `exists?` with `exist?`

### DIFF
--- a/lib/puppet_https.rb
+++ b/lib/puppet_https.rb
@@ -21,7 +21,7 @@ class PuppetHttps
     cert_path    = settings['certificate_path']
     pkey_path    = settings['private_key_path']
 
-    @ca_file      = settings['ca_certificate_path'] if ca_cert_path and File.exists?(ca_cert_path)
+    @ca_file      = settings['ca_certificate_path'] if ca_cert_path and File.exist?(ca_cert_path)
     @read_timeout = settings['read_timeout'] || 90 # A default timeout value in seconds
 
     @auth_method = case
@@ -29,7 +29,7 @@ class PuppetHttps
         'token'
       when (cert_path and pkey_path)
         'cert'
-      when default_token_path && File.exists?(default_token_path)
+      when default_token_path && File.exist?(default_token_path)
         'token'
       else
         nil
@@ -47,13 +47,13 @@ class PuppetHttps
       case
       when (@token and @token.empty?)
         raise RuntimeError, "Received an empty string for token"
-      when (not @token and not File.exists?(@token_path))
+      when (not @token and not File.exist?(@token_path))
         raise RuntimeError, "Token file not found at [#{@token_path}]"
       when (not @token and File.zero?(@token_path))
         raise RuntimeError, "Token file at [#{@token_path}] is empty"
       end
     when 'cert'
-      if File.exists?(cert_path) and File.exists?(pkey_path)
+      if File.exist?(cert_path) and File.exist?(pkey_path)
         @cert = OpenSSL::X509::Certificate.new(File.read(cert_path))
         @key  = OpenSSL::PKey::RSA.new(File.read(pkey_path))
       else
@@ -131,7 +131,7 @@ class PuppetHttps
 
   def token
     return @token if @token
-    if @token_path and File.exists?(@token_path)
+    if @token_path and File.exist?(@token_path)
       @token = File.read(@token_path)
       return @token
     end

--- a/spec/puppet_https_spec.rb
+++ b/spec/puppet_https_spec.rb
@@ -16,9 +16,9 @@ describe PuppetHttps do
         "ca_certificate_path" => ca_certificate_path,
       }
 
-      expect(File).to receive("exists?").with(certificate_path).and_return(true)
-      expect(File).to receive("exists?").with(private_key_path).and_return(true)
-      expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+      expect(File).to receive("exist?").with(certificate_path).and_return(true)
+      expect(File).to receive("exist?").with(private_key_path).and_return(true)
+      expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
       expect(File).to receive("read").with(certificate_path).and_return('a cert')
       expect(File).to receive("read").with(private_key_path).and_return('a key')
@@ -84,9 +84,9 @@ describe PuppetHttps do
           "token_path"          => "/home/foo/.puppetlabs/token",
         }
 
-        expect(File).to receive(:exists?).with("/home/foo/.puppetlabs/token").and_return(true)
+        expect(File).to receive(:exist?).with("/home/foo/.puppetlabs/token").and_return(true)
         expect(File).to receive(:zero?).with("/home/foo/.puppetlabs/token").and_return(false)
-        expect(File).to receive(:exists?).with(auth_info['ca_certificate_path']).and_return(true)
+        expect(File).to receive(:exist?).with(auth_info['ca_certificate_path']).and_return(true)
 
         @puppet_https = PuppetHttps.new(auth_info)
         expect(@puppet_https).to be_an_instance_of PuppetHttps
@@ -104,7 +104,7 @@ describe PuppetHttps do
         auth_info = {
           "token_path"          => "/no/such/path",
         }
-        expect(File).to receive(:exists?).with("/no/such/path").and_return(false)
+        expect(File).to receive(:exist?).with("/no/such/path").and_return(false)
         expect { @puppet_https = PuppetHttps.new(auth_info) }.to raise_error(RuntimeError, 'Token file not found at [/no/such/path]')
       end
     end
@@ -116,7 +116,7 @@ describe PuppetHttps do
     describe "and a token file at the default location" do
       it "uses the token file from the default location" do
         allow(ENV).to receive(:[]).with("HOME").and_return("/homie/foo")
-        expect(File).to receive("exists?").with(default_token_path).twice.and_return(true)
+        expect(File).to receive("exist?").with(default_token_path).twice.and_return(true)
         @puppet_https = PuppetHttps.new({})
         expect(@puppet_https).to be_an_instance_of PuppetHttps
         expect(@puppet_https).to have_attributes(
@@ -130,7 +130,7 @@ describe PuppetHttps do
 
       it "raises an exception" do
         allow(ENV).to receive(:[]).with("HOME").and_return("/homie/foo")
-        expect(File).to receive("exists?").twice.with(default_token_path).and_return(true)
+        expect(File).to receive("exist?").twice.with(default_token_path).and_return(true)
         expect(File).to receive("zero?").with(default_token_path).and_return(true)
 
         expect { @puppet_https = PuppetHttps.new({}) }.to raise_error(RuntimeError, "Token file at [#{default_token_path}] is empty")
@@ -140,7 +140,7 @@ describe PuppetHttps do
     describe "and no token file at the default location" do
       it "raises an exception" do
         allow(ENV).to receive(:[]).with("HOME").and_return("/homie/foo")
-        expect(File).to receive("exists?").with(default_token_path).and_return(false)
+        expect(File).to receive("exist?").with(default_token_path).and_return(false)
         expect { @puppet_https = PuppetHttps.new({}) }.to raise_error(RuntimeError, /No authentication methods available/)
       end
     end

--- a/spec/puppetclassify/classes_spec.rb
+++ b/spec/puppetclassify/classes_spec.rb
@@ -16,9 +16,9 @@ describe Classes do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/commands_spec.rb
+++ b/spec/puppetclassify/commands_spec.rb
@@ -15,9 +15,9 @@ describe Commands do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/environments_spec.rb
+++ b/spec/puppetclassify/environments_spec.rb
@@ -15,9 +15,9 @@ describe Environments do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/groups_spec.rb
+++ b/spec/puppetclassify/groups_spec.rb
@@ -15,9 +15,9 @@ describe Groups do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/import_hierarchy_spec.rb
+++ b/spec/puppetclassify/import_hierarchy_spec.rb
@@ -15,9 +15,9 @@ describe ImportHierarchy do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/last_class_update_spec.rb
+++ b/spec/puppetclassify/last_class_update_spec.rb
@@ -16,9 +16,9 @@ describe LastClassUpdate do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/nodes_spec.rb
+++ b/spec/puppetclassify/nodes_spec.rb
@@ -15,9 +15,9 @@ describe Nodes do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/rules_spec.rb
+++ b/spec/puppetclassify/rules_spec.rb
@@ -15,9 +15,9 @@ describe Rules do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/update_classes_spec.rb
+++ b/spec/puppetclassify/update_classes_spec.rb
@@ -15,9 +15,9 @@ describe UpdateClasses do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify/validate_spec.rb
+++ b/spec/puppetclassify/validate_spec.rb
@@ -15,9 +15,9 @@ describe Validate do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')

--- a/spec/puppetclassify_spec.rb
+++ b/spec/puppetclassify_spec.rb
@@ -15,9 +15,9 @@ describe PuppetClassify do
       "ca_certificate_path" => ca_certificate_path,
     }
 
-    expect(File).to receive("exists?").with(certificate_path).and_return(true)
-    expect(File).to receive("exists?").with(private_key_path).and_return(true)
-    expect(File).to receive("exists?").with(ca_certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(certificate_path).and_return(true)
+    expect(File).to receive("exist?").with(private_key_path).and_return(true)
+    expect(File).to receive("exist?").with(ca_certificate_path).and_return(true)
 
     expect(File).to receive("read").with(certificate_path).and_return('a cert')
     expect(File).to receive("read").with(private_key_path).and_return('a key')


### PR DESCRIPTION
`exists?` doesn't exist anymore in Ruby 3.2, it's not `exist?`:

https://github.com/puppetlabs/puppet/wiki/Puppet-8-Compatibility#filedirexists-removed

It was already deprecated in Ruby 2.1:

https://bugs.ruby-lang.org/issues/17391